### PR TITLE
FIX: properly emit Content-Type header.

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -54,8 +54,8 @@ func (h *healthCheckHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Write HTTP response
 	disableResponseCache(w)
-	w.WriteHeader(mapHTTPStatus(&h.cfg, res.Status))
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(mapHTTPStatus(&h.cfg, res.Status))
 	w.Write(jsonResp)
 }
 


### PR DESCRIPTION
Setting the `Content-Type` header after the `WriteHeader()` call had it ignored.