### PR TITLE
Export handlerConfig struct

### DIFF
--- a/config.go
+++ b/config.go
@@ -48,7 +48,7 @@ type (
 	CheckerOption func(config *checkerConfig)
 
 	// HandlerOption is a configuration option for a Handler (see NewHandler).
-	HandlerOption func(*handlerConfig)
+	HandlerOption func(*HandlerConfig)
 )
 
 // NewChecker creates a new Checker. The provided options will be
@@ -110,7 +110,7 @@ func WithStatusListener(listener func(ctx context.Context, state CheckerState)) 
 // to pro- and post-process HTTP requests and health checks.
 // Refer to the documentation of type Middleware for more information.
 func WithMiddleware(middleware ...Middleware) HandlerOption {
-	return func(cfg *handlerConfig) {
+	return func(cfg *HandlerConfig) {
 		cfg.middleware = append(cfg.middleware, middleware...)
 	}
 }
@@ -119,7 +119,7 @@ func WithMiddleware(middleware ...Middleware) HandlerOption {
 // where the system is considered to be available ("up").
 // Default is HTTP status code 200 (OK).
 func WithStatusCodeUp(httpStatus int) HandlerOption {
-	return func(cfg *handlerConfig) {
+	return func(cfg *HandlerConfig) {
 		cfg.statusCodeUp = httpStatus
 	}
 }
@@ -128,7 +128,7 @@ func WithStatusCodeUp(httpStatus int) HandlerOption {
 // where the system is considered to be unavailable ("down").
 // Default is HTTP status code 503 (Service Unavailable).
 func WithStatusCodeDown(httpStatus int) HandlerOption {
-	return func(cfg *handlerConfig) {
+	return func(cfg *HandlerConfig) {
 		cfg.statusCodeDown = httpStatus
 	}
 }
@@ -136,7 +136,7 @@ func WithStatusCodeDown(httpStatus int) HandlerOption {
 // WithResultWriter is responsible for writing a health check result (see CheckerResult)
 // into an HTTP response. By default, JSONResultWriter will be used.
 func WithResultWriter(writer ResultWriter) HandlerOption {
-	return func(cfg *handlerConfig) {
+	return func(cfg *HandlerConfig) {
 		cfg.resultWriter = writer
 	}
 }

--- a/config_test.go
+++ b/config_test.go
@@ -99,7 +99,7 @@ func TestWithDisabledDetailsConfig(t *testing.T) {
 
 func TestWithMiddlewareConfig(t *testing.T) {
 	// Arrange
-	cfg := handlerConfig{}
+	cfg := HandlerConfig{}
 	mw := func(MiddlewareFunc) MiddlewareFunc {
 		return func(r *http.Request) CheckerResult {
 			return CheckerResult{StatusUp, nil}
@@ -131,7 +131,7 @@ func TestWithInterceptorConfig(t *testing.T) {
 
 func TestWithResultWriterConfig(t *testing.T) {
 	// Arrange
-	cfg := handlerConfig{}
+	cfg := HandlerConfig{}
 	w := resultWriterMock{}
 
 	// Act

--- a/handler.go
+++ b/handler.go
@@ -7,7 +7,7 @@ import (
 )
 
 type (
-	handlerConfig struct {
+	HandlerConfig struct {
 		statusCodeUp   int
 		statusCodeDown int
 		middleware     []Middleware
@@ -95,8 +95,8 @@ func mapHTTPStatusCode(status AvailabilityStatus, statusCodeUp int, statusCodeDo
 	return statusCodeUp
 }
 
-func createConfig(options []HandlerOption) handlerConfig {
-	cfg := handlerConfig{
+func createConfig(options []HandlerOption) HandlerConfig {
+	cfg := HandlerConfig{
 		statusCodeDown: 503,
 		statusCodeUp:   200,
 		middleware:     []Middleware{},


### PR DESCRIPTION
Can be useful when we want to customize HTTP response code for a checker outside the package 