### PR TITLE
feature: streaming checks

### DIFF
--- a/async_check_input.go
+++ b/async_check_input.go
@@ -1,0 +1,53 @@
+package health
+
+import (
+	"context"
+	"time"
+)
+
+type (
+	AsyncCheckRunInput struct {
+		Context      context.Context
+		CurrentState CheckState
+	}
+	AsyncCheckInput interface {
+		Context() context.Context
+		GetInputForCheck() AsyncCheckRunInput
+	}
+
+	asyncCheckInput struct {
+		context             context.Context
+		firstCheckStartedAt time.Time
+		currentState        CheckState
+		waitForNext         chan struct{}
+	}
+)
+
+func newAsyncCheckInput(ctx context.Context) *asyncCheckInput {
+	return &asyncCheckInput{
+		context:     ctx,
+		waitForNext: make(chan struct{}),
+	}
+}
+
+func (input *asyncCheckInput) Context() context.Context {
+	return input.context
+}
+
+func (input *asyncCheckInput) GetInputForCheck() AsyncCheckRunInput {
+	<-input.waitForNext
+	if input.firstCheckStartedAt.IsZero() {
+		input.firstCheckStartedAt = time.Now().UTC()
+	}
+	input.waitForNext = make(chan struct{})
+	return AsyncCheckRunInput{
+		Context:      input.context,
+		CurrentState: input.currentState,
+	}
+}
+
+func (input *asyncCheckInput) updateStateForNextCheck(ctx context.Context, state CheckState) {
+	input.context = ctx
+	input.currentState = state
+	close(input.waitForNext)
+}

--- a/config_test.go
+++ b/config_test.go
@@ -14,31 +14,33 @@ import (
 func TestWithPeriodicCheckConfig(t *testing.T) {
 	// Arrange
 	expectedName := "test"
-	cfg := checkerConfig{checks: map[string]*Check{}}
+	cfg := checkerConfig{syncChecks: map[string]*Check{}, asyncChecks: map[string]asyncCheck{}}
 	interval := 5 * time.Second
 	initialDelay := 1 * time.Minute
-	check := Check{Name: expectedName, updateInterval: interval, initialDelay: initialDelay}
+	check := Check{Name: expectedName}
 
 	// Act
 	WithPeriodicCheck(interval, initialDelay, check)(&cfg)
 
 	// Assert
-	assert.Equal(t, 1, len(cfg.checks))
-	assert.True(t, reflect.DeepEqual(check, *cfg.checks[expectedName]))
+	assert.Equal(t, 1, len(cfg.asyncChecks))
+	if p, ok := cfg.asyncChecks[expectedName].(*periodicCheck); assert.True(t, ok) {
+		assert.True(t, reflect.DeepEqual(check, p.Check))
+	}
 }
 
 func TestWithCheckConfig(t *testing.T) {
 	// Arrange
 	expectedName := "test"
-	cfg := checkerConfig{checks: map[string]*Check{}}
+	cfg := checkerConfig{syncChecks: map[string]*Check{}}
 	check := Check{Name: "test"}
 
 	// Act
 	WithCheck(check)(&cfg)
 
 	// Assert
-	require.Equal(t, 1, len(cfg.checks))
-	assert.True(t, reflect.DeepEqual(&check, cfg.checks[expectedName]))
+	require.Equal(t, 1, len(cfg.syncChecks))
+	assert.True(t, reflect.DeepEqual(&check, cfg.syncChecks[expectedName]))
 }
 
 func TestWithCacheDurationConfig(t *testing.T) {

--- a/periodic_check.go
+++ b/periodic_check.go
@@ -1,0 +1,45 @@
+package health
+
+import "context"
+
+func (check *periodicCheck) name() string {
+	return check.Name
+}
+
+func (check *periodicCheck) interceptors() []Interceptor {
+	return check.Interceptors
+}
+
+func (check *periodicCheck) start(input AsyncCheckInput) chan error {
+	checkChannel := make(chan error)
+
+	go func() {
+		defer close(checkChannel)
+
+		if check.initialDelay > 0 {
+			if waitForStopSignal(input.Context(), check.initialDelay) {
+				return
+			}
+		}
+
+		for {
+			runInput := input.GetInputForCheck() // This will wait until the input is ready for the next run
+			ctx, cancel := context.WithCancel(runInput.Context)
+			if check.Timeout > 0 {
+				ctx, cancel = context.WithTimeout(ctx, check.Timeout)
+			}
+
+			// ATTENTION: This function may panic, if panic handling is disabled
+			// 	via "check.DisablePanicRecovery".
+
+			checkChannel <- executeCheckFunc(ctx, &check.Check)
+			cancel()
+
+			if waitForStopSignal(runInput.Context, check.updateInterval) {
+				return
+			}
+		}
+	}()
+
+	return checkChannel
+}

--- a/streaming_check.go
+++ b/streaming_check.go
@@ -1,0 +1,32 @@
+package health
+
+import (
+	"context"
+	"time"
+)
+
+func (c *streamingCheck) start(input AsyncCheckInput) chan error {
+	return c.makeCheckStream(input)
+}
+
+func (c *BaseCheck) name() string {
+	return c.Name
+}
+
+func (c *BaseCheck) interceptors() []Interceptor {
+	return c.Interceptors
+}
+
+func (c *BaseCheck) onStateChange(ctx context.Context, oldState CheckState, newState CheckState) {
+	c.StatusListener.onStateChange(ctx, c.Name, oldState, newState)
+}
+
+// maxFails implements evaluateCheckConfig.
+func (c *BaseCheck) maxFails() uint {
+	return c.MaxContiguousFails
+}
+
+// maxTimeInError implements evaluateCheckConfig.
+func (c *BaseCheck) maxTimeInError() time.Duration {
+	return c.MaxTimeInError
+}

--- a/sync_check.go
+++ b/sync_check.go
@@ -1,0 +1,20 @@
+package health
+
+import (
+	"context"
+	"time"
+)
+
+func (c *Check) onStateChange(ctx context.Context, oldState CheckState, newState CheckState) {
+	c.StatusListener.onStateChange(ctx, c.Name, oldState, newState)
+}
+
+// maxFails implements evaluateCheckConfig.
+func (c *Check) maxFails() uint {
+	return c.MaxContiguousFails
+}
+
+// maxTimeInError implements evaluateCheckConfig.
+func (c *Check) maxTimeInError() time.Duration {
+	return c.MaxTimeInError
+}


### PR DESCRIPTION
I recognize that this is a big change and may not be accepted, but wanted to get the idea out there. I'm pretty sure it's not a breaking change though.

I started looking at using this library with [gRPC health checks](https://github.com/grpc/grpc-proto/blob/master/grpc/health/v1/health.proto) but couldn't figure out how to utilize the `stream` option where the server pushes status updates.

So I made this PR as an example of "streaming" check: a check that listens for updates on a go channel (dependency pushes health check updates instead of this app pulling them).

This "streaming" check is a more generic form of the periodic check. So I implemented the periodic check as a streaming check internally. 
A streaming check could be built upon for extremely custom async checks like
- while healthy, check every x seconds
- on first fail, check more frequently on exponential backoff

Other tweaks
- made separate, read-write mutexs. This _might_ be more performance but mostly for clarity.
- allow setting the root context of the async checks

Comments
- a periodic check with a period of 0 was literally indistinguishable in code from a sync check. I found this really confusing when working with the unit tests. With this PR, that is no longer true.