### PR TITLE
feat(config): Add WithChecks() option pattern func

### DIFF
--- a/config.go
+++ b/config.go
@@ -162,8 +162,16 @@ func WithCacheDuration(duration time.Duration) CheckerOption {
 // If health checks are expensive, or you expect a higher amount of requests on the health endpoint,
 // consider using WithPeriodicCheck instead.
 func WithCheck(check Check) CheckerOption {
+	return WithChecks(check)
+}
+
+// WithChecks adds a list of health checks that contribute to the overall service availability status.
+// see. WithCheck for more information.
+func WithChecks(checks ...Check) CheckerOption {
 	return func(cfg *checkerConfig) {
-		cfg.checks[check.Name] = &check
+		for i := range checks {
+			cfg.checks[checks[i].Name] = &checks[i]
+		}
 	}
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -41,6 +41,25 @@ func TestWithCheckConfig(t *testing.T) {
 	assert.True(t, reflect.DeepEqual(&check, cfg.checks[expectedName]))
 }
 
+func TestWithChecksConfig(t *testing.T) {
+	// Arrange
+	expectedNames := []string{"test1", "test2"}
+	cfg := checkerConfig{checks: map[string]*Check{}}
+	checks := []Check{
+		{Name: "test1"},
+		{Name: "test2"},
+	}
+
+	// Act
+	WithChecks(checks...)(&cfg)
+
+	// Assert
+	require.Equal(t, 2, len(cfg.checks))
+	for i, name := range expectedNames {
+		assert.True(t, reflect.DeepEqual(&checks[i], cfg.checks[name]))
+	}
+}
+
 func TestWithCacheDurationConfig(t *testing.T) {
 	// Arrange
 	cfg := checkerConfig{}


### PR DESCRIPTION
Thank you for this great library!

This PR adds a new `WithChecks` function that allows the dynamic addition of multiple health checks during initialization. This enhancement provides more flexibility in configuring health checks at startup.

This PR addresses the issue discussed in [Issue #87](https://github.com/alexliesenfeld/health/issues/87) (already closed...).

## Changes

- Introduced the `WithChecks` function to enable setting multiple health checks at once.
- Modified the `WithCheck` function to utilize `WithChecks`.

## Use Case

In my use case, I want to provide a common health check initialization function and be able to add specific checks for service A, for instance. This change allows the flexible addition of health checks to the common initialization function.